### PR TITLE
Fix verifier must be NULL after creation

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,8 +10,10 @@ parameters:
         - ./tests
     excludePaths:
         - var/
-        - templates/
-        - translations/
 
     ignoreErrors:
-        - '#Attribute class Symfony\\Contracts\\Service\\Attribute\\Required does not exist#' # Not required
+        # Not required
+        - '#Attribute class Symfony\\Contracts\\Service\\Attribute\\Required does not exist#'
+
+         # Always set, as it's only NULL after zeroing, which happens later
+        - '#Parameter \#1 \$verifier of method Rollerworks\\Component\\SplitToken\\SplitToken\:\:hashVerifier\(\) expects string, string\|null given#'

--- a/src/SplitToken.php
+++ b/src/SplitToken.php
@@ -94,7 +94,7 @@ abstract class SplitToken
     protected array $config = [];
     private HiddenString $token;
     private string $selector;
-    private string $verifier;
+    private ?string $verifier;
     private ?string $verifierHash = null;
     private ?\DateTimeImmutable $expiresAt = null;
 
@@ -201,6 +201,10 @@ abstract class SplitToken
 
         if ($token->isExpired() || $token->selector() !== $this->selector) {
             return false;
+        }
+
+        if ($this->verifier === null) {
+            throw new \RuntimeException('matches() does not work with a SplitToken object when created with create(), use fromString() instead.');
         }
 
         return $this->verifyHash($token->verifierHash(), $this->verifier);

--- a/tests/Argon2SplitTokenTest.php
+++ b/tests/Argon2SplitTokenTest.php
@@ -167,6 +167,17 @@ final class Argon2SplitTokenTest extends TestCase
     }
 
     #[Test]
+    public function it_fails_matches_when_just_created(): void
+    {
+        $splitToken = SplitToken::create(self::$randValue);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('matches() does not work with a SplitToken object when created with create(), use fromString() instead.');
+
+        $splitToken->matches($splitToken->toValueHolder());
+    }
+
+    #[Test]
     public function it_verifies_split_token(): void
     {
         // Stored.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

The `create()` method zeroes the verifier after usage but the property didn't allow a null value